### PR TITLE
John conroy/update manifest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 0.0.13 - 2023-02-01
 - Update publish.sh to include license and prune unneeded files in sdist.
+- Update manifest.in and dev dependencies for new build process.
 
 0.0.12 - 2020-12-15
 - Check for changelog updates with each PR.

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,8 @@
+include VERSION
 exclude .gitignore
 exclude .travis.yml
 exclude publish.sh
 exclude test-cli.sh
 exclude test.sh
+exclude .pypirc
 prune tests

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,4 +3,4 @@ autopep8==1.5.4
 pytest==6.1.1
 yattag==1.14.0
 twine==3.2.0
-build==0.10.0
+build==0.9.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,3 +3,4 @@ autopep8==1.5.4
 pytest==6.1.1
 yattag==1.14.0
 twine==3.2.0
+build==0.10.0


### PR DESCRIPTION
Update manifest to include VERSION since it is referenced in `setup.py` and exclude the `.pypirc` token. Add build as a dev dependency.